### PR TITLE
Set encoding of QuotedString instead of calling prepare()

### DIFF
--- a/djorm_pgfulltext/utils.py
+++ b/djorm_pgfulltext/utils.py
@@ -7,5 +7,5 @@ from django.utils.text import force_text
 def adapt(text):
     connection.ensure_connection()
     a = psycopg2.extensions.adapt(force_text(text))
-    a.prepare(connection.connection)
+    a.encoding = connection.connection.encoding
     return a


### PR DESCRIPTION
As described in https://github.com/18F/calc/issues/1498, NewRelic database instrumentation makes passing a connection to `QuotedString::prepare()` problematic.

This commit attempts to work around the problem by setting the encoding of the `QuotedString` to the connection's encoding, which *seems* like a decent workaround, as that looks like most of what the [`QuotedString`][] uses the connection for.

The one exception to this is when `QuotedString::getquoted()` is called, in which case [`psycopg_escape_string`][] is called. This function appears to call [`PQescapeString`][] if it's passed a `NULL` database connection, which according to the Postgres documentation should work okay as long as we "only work with one PostgreSQL connection at a time".

[`QuotedString`]: https://github.com/psycopg/psycopg2/blob/d2cd1236a8638eeee39d78187e76572ed6bfc19d/psycopg/adapter_qstring.c
[`psycopg_escape_string`]: https://github.com/psycopg/psycopg2/blob/f9b36433fb0103f0e98fe3d579103e0352667315/psycopg/utils.c
[`PQescapeString`]: https://www.postgresql.org/docs/9.6/static/libpq-exec.html