### PR TITLE
Unwrap connection if needed.

### DIFF
--- a/djorm_pgfulltext/utils.py
+++ b/djorm_pgfulltext/utils.py
@@ -7,5 +7,11 @@ from django.utils.text import force_text
 def adapt(text):
     connection.ensure_connection()
     a = psycopg2.extensions.adapt(force_text(text))
-    a.prepare(connection.connection)
+    c = connection.connection
+
+    # This is a workaround for https://github.com/18F/calc/issues/1498.
+    if hasattr(c, '__wrapped__'):
+        c = getattr(c, '__wrapped__')
+
+    a.prepare(c)
     return a


### PR DESCRIPTION
This is yet another alternative fix for https://github.com/18F/calc/issues/1498.

The newrelic agent internally uses a package called [`wrapt`](https://wrapt.readthedocs.io/en/latest/) to wrap database connections (among other things).  An undocumented property of wrappers, but defined in [`_wrappers.c`](https://github.com/GrahamDumpleton/wrapt/blob/develop/src/wrapt/_wrappers.c), is the `__wrapped__` property, which allows us to "unwrap" the object contained in the wrapper.

This PR checks to see if `__wrapped__` exists on the object and, if so, unwraps it.

Note that my original attempt checked to see if the wrapper was an instance of a psycopg2 connection, but this didn't work--the wrapper is so completely convincing that it fooled `isinstance()` into thinking that it was actually the real thing.  But I guess Python's C API is not so easily fooled.
