### PR TITLE
Add add_arguments() method to update_search_field command.

### DIFF
--- a/djorm_pgfulltext/management/commands/update_search_field.py
+++ b/djorm_pgfulltext/management/commands/update_search_field.py
@@ -11,6 +11,10 @@ class Command(BaseCommand):
     help = 'Update search fields'
     args = "appname [model]"
 
+    def add_arguments(self, parser):
+        parser.add_argument('app', type=str)
+        parser.add_argument('model', type=str)
+
     def handle(self, app=None, model=None, **options):
         if not app:
             raise CommandError("You must provide an app to update search fields.")

--- a/djorm_pgfulltext/management/commands/update_search_field.py
+++ b/djorm_pgfulltext/management/commands/update_search_field.py
@@ -9,11 +9,10 @@ from django.apps import apps
 
 class Command(BaseCommand):
     help = 'Update search fields'
-    args = "appname [model]"
 
     def add_arguments(self, parser):
         parser.add_argument('app', type=str)
-        parser.add_argument('model', type=str)
+        parser.add_argument('model', type=str, nargs='?')
 
     def handle(self, app=None, model=None, **options):
         if not app:


### PR DESCRIPTION
In Django 1.10, running the `update_search_field` command with `contracts contract` positional arguments fails with the following error:

```
django.core.management.base.CommandError: Error: unrecognized arguments: contracts contract
```

This fixes the problem by adding an `add_arguments` method to the command's `Command` subclass and explicitly defining the arguments through the `argparse` API.  It doesn't impede the command's functioning in Django 1.9.
